### PR TITLE
Added fallback for `options` when no options specified

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -14,6 +14,8 @@
 
     i18n.init = function(options, cb) {
 
+        options || (options = {});
+
         options.resSetPath = options.resSetPath || 'locales/__lng__/__ns__.json';
         options.sendMissing = options.saveMissing || false;
 


### PR DESCRIPTION
There is no check if `options` were not specified in `init` method of i18next. Calling i18next.init() without options causes node to crash. I've added such a checking. Please have a look ,)
