### PR TITLE
Set cookie httpOnly to false

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -131,7 +131,7 @@
         var expirationDate = new Date();
         expirationDate.setFullYear(expirationDate.getFullYear() + 1);
 
-        cookies.set('i18next', locale, { expires: expirationDate });
+        cookies.set('i18next', locale, { expires: expirationDate, httpOnly : false });
     };
 
 })();


### PR DESCRIPTION
Setting httpOnly to false prevents a but which does not allow i18next client-side script to read/write cookie as a result it don't keep the state of the current set language so if you have `en-US` as a fallback language and you access the page you'll get `en-US` locale, if you try to access the page with `/?setLng=el-GR` then you'll get `el-GR` locale but once you remove `/?setLng=el-GR` because i18next had already set `i18next` cookie with `httpOnly` set to `true` you cannot modify the value of this cookie or read it so you end up by getting the fallback language again.
