### PR TITLE
Link to public git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.2.3",
   "repository": {
     "type": "git",
-    "url": "git@github.com:jamuhl/i18next-node.git"
+    "url": "git://github.com/jamuhl/i18next-node.git"
   },
   "private": false,
   "main": "index.js",


### PR DESCRIPTION
Pros:
-   link to github in npm registry
-   people can directly fork this repo without SSH
