### PR TITLE
i18next-1.2.4.js expects to dynamically load /locales/:lng/:ns.json and not /locales/resources.json

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -101,14 +101,14 @@
     };
 
     i18n.serveDynamicResources = function(app) {
-        app.get('/locales/resources.json', function(req, res) {
+        app.get('/locales/:lng/:ns.json', function(req, res) {
 
             var resources = {};
 
             res.contentType('json');
 
-            languages = req.query.lng.split(' ');
-            namespaces = req.query.ns.split(' ');
+            languages = req.param('lng').split('+');
+            namespaces = req.param('ns').split('+');
 
             i18n.sync.load(languages, {namespaces: namespaces}, false, false, function() {
 


### PR DESCRIPTION
Fix for that.

Also, feature request:
would be good to automatically generate the resource files (/locales/:lng/:ns.json) like i18n-node does. That's an awesome feature.

Thanks and keep it up!
