### PR TITLE
If there are any problem with reaching the translation files it's not that easy to find out where's the problem.

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -71,6 +71,7 @@
 
         fs.readFile(filename, 'utf8', function(err, data) {
             if (err) {
+                console.log(err);
                 cb(err);
             } else {
                 cb(null, JSON.parse(data));


### PR DESCRIPTION
It took me a lot of time to understand why the translation wasn't working on OS X. The project worked, but instead of the _values_ the _keys_ were used.

It looks like NodeJS on OS X does not accept relative paths for fs.readFile, so resGetPath should be changed to absolute path.

The module does not tell that there's a problem with the path. So this **console.log** should help in such cases.
