### PR TITLE
Fixes #21. i18n.serveMissingKeyRoute causes error upon client ajax callback

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -152,7 +152,8 @@
                 i18n.sync.postMissing(ns, m, req.body[m]);
             }
 
-            res.send('OK');
+            var response = {"response": "OK"};
+            res.send(JSON.stringify(response));
         });
 
         return i18n;


### PR DESCRIPTION
Without this fix i18n.serveMissingKeyRoute causes error callback in postMissing func when adding new language keys from client side.
