### PR TITLE
Guard against splitting undefined

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -122,8 +122,8 @@
 
             res.contentType('json');
 
-            var languages = req.query.lng.split(' ')
-              , opts = { ns: { namespaces: req.query.ns.split(' ') } };
+            var languages = req.query.lng ? req.query.lng.split(' ') : []
+              , opts = { ns: { namespaces: req.query.ns ? req.query.ns.split(' ') : [] } };
 
             i18n.sync.load(languages, opts, function() {
 


### PR DESCRIPTION
> /locales/resources.json TypeError: Cannot call method 'split' of undefined
>     at ./node_modules/i18next/lib/i18next.js:125:43

When getting without querystring parameters.

ie. `/locales/resources.json` instead of `/locales/resources.json?lng=en&ns=frontend`
