### PR TITLE
fix exception while saving notfound translation

### DIFF
--- a/lib/dep/i18next-1.5.6.js
+++ b/lib/dep/i18next-1.5.6.js
@@ -801,9 +801,9 @@
     
         if (!found && o.sendMissing) {
             if (options.lng) {
-                sync.postMissing(options.lng, ns, key, notfound, lngs);
+                sync.postMissing(options.lng, ns, key, notfound);
             } else {
-                sync.postMissing(o.lng, ns, key, notfound, lngs);
+                sync.postMissing(o.lng, ns, key, notfound);
             }
         }
     


### PR DESCRIPTION
in the current 'master' within upstream the implementation passes `lngs` as last argument where `postMissing` method expects callback.

Because of that when there translation is not found, i18next throws ugly error. 

I've ran all tests and they are passing, please once you have time check them as well as the fix.
