### PR TITLE
fix: plurals in russian

### DIFF
--- a/lib/dep/i18next-1.5.9.js
+++ b/lib/dep/i18next-1.5.9.js
@@ -1899,11 +1899,22 @@
             "ru": {
                 "name": "Russian", 
                 "numbers": [
-                    5, 
-                    1, 
-                    2
+                    0,
+                    1,
+                    2,
+                    5
                 ], 
-                "plurals": function(n) { return Number(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2); }
+                "plurals": function(n) {
+                    var lastDigit     = n % 10;
+                    var lastTwoDigits = n % 100;
+                    if (0 === n)
+                        return 0;
+                    if ((lastDigit === 1) && (lastTwoDigits !== 11))
+                        return 1;
+                    if ((lastDigit >= 2) && (lastDigit <= 4) && ((lastTwoDigits < 10) || (lastTwoDigits >= 20)))
+                        return 2;
+                    return 3;
+                }
             }, 
             "sah": {
                 "name": "Yakut", 


### PR DESCRIPTION
Fixed kind of messy russian plurals.
Added ability to set different translation when `n == 0` (like "no items" in english instead of "0 items").
Calcualting `n % 10` and `n % 100` multiple times aren't really nice either.
