### PR TITLE
Fixed `opts.supportedLngs`

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -26,7 +26,8 @@
         options.sendMissing = options.saveMissing || false;
         options.detectLngFromPath = options.detectLngFromPath === undefined ? false : options.detectLngFromPath;
         options.forceDetectLngFromPath = options.forceDetectLngFromPath !== true ? false : options.forceDetectLngFromPath;
-        options.supportedLngs = [];
+        options.supportedLngs = options.supportedLngs || undefined;   // just to make the default value clear
+        options.fallbackLng = options.fallbackLng || 'en';
         options.ignoreRoutes = options.ignoreRoutes || [];
         options.cookieName = options.cookieName || 'i18next';  
         resStore = options.resStore ? options.resStore : {};

--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -14,10 +14,26 @@
         module.exports = wrapper;
     }
 
+    // checks if there are rules registered for a given locale
+    var _rulesExist = function(locale) {
+        return !!wrapper.pluralExtensions.rules[locale.split(/[\-_]/)[0]];
+    };
+
+    // checks if the locale is supported
+    var _isSupportedLocale = function(locale) {
+        var opts = wrapper.options;
+
+        // any of the supported locales
+        if (Array.isArray(opts.supportedLngs)) return opts.supportedLngs.indexOf(locale) > -1;
+
+        // any locale with registered rules
+        return _rulesExist(locale);
+    };
+
+
     // overriding detect language function
     var detectLanguage = function(req, res) {
-        var querystring, cookies, headers, query, cookie, locale
-          , locales = []
+        var locale, querystring, cookies, _lng
           , opts = wrapper.options;
 
         if (typeof req === 'object') {
@@ -25,9 +41,8 @@
             if (opts.detectLngFromPath !== false) {
                 var parts = req.originalUrl.split('/');
                 if (parts.length > opts.detectLngFromPath) {
-                    var part = parts[opts.detectLngFromPath + 1];
-                    var lookUp = wrapper.pluralExtensions.rules[part.split('-')[0]];
-                    if (lookUp && (opts.supportedLngs.length === 0 || opts.supportedLngs.indexOf(lookUp) > -1)) locale = part;
+                    _lng = parts[opts.detectLngFromPath + 1];
+                    if (_lng && _isSupportedLocale(_lng)) locale = _lng;
                 }
 
                 if (!locale && opts.forceDetectLngFromPath) {
@@ -36,73 +51,85 @@
             }
 
             if (!locale) { 
-                querystring = url.parse(req.url, true);
-                if (querystring.search) locale = querystring.query[opts.detectLngQS];
+                if (req.query) {
+                    _lng = req.query[opts.detectLngQS];
+                } else {
+                    querystring = url.parse(req.url, true);
+                    _lng = querystring.query[opts.detectLngQS];
+                }
+                if (_lng && _isSupportedLocale(_lng)) locale = _lng;
             }
             
             if (!locale && opts.useCookie) {
-                cookies = new Cookies(req, res);
-                locale = cookies.get(opts.cookieName);
+                if (req.cookies) {
+                    _lng = req.cookies[opts.cookieName];
+                } else {
+                    cookies = new Cookies(req, res);
+                    _lng = cookies.get(opts.cookieName);
+                }
+                if (_lng && _isSupportedLocale(_lng)) locale = _lng;
             }
             
-            if (locale) {
-                locales.push(locale);
-            } else { 
-                locales = _extractLocales(req.headers);
-            }
-        }
-
-        if (locales.length === 0) locales.push(opts.fallbackLng || 'en');
-
-        return locales[0];
-    };
-
-    var _extractLocales = function(headers) {
-        var locales = [];
-
-        if (!headers) {
-            return i18n.options.fallbackLng;
-        }
-
-        var acceptLanguage = headers['accept-language'];
-
-        if (acceptLanguage) {
-            var lngs = [];
-
-            // associate language tags by their 'q' value (between 1 and 0)
-            acceptLanguage.split(',').forEach(function(l) {
-                var parts = l.split(';'); // 'en-GB;q=0.8' -> ['en-GB', 'q=0.8']
-
-                // get the language tag qvalue: 'q=0.8' -> 0.8
-                var qvalue = 1; // default qvalue
-                var i;
-                for (i = 0; i < parts.length; i++) {
-                    var part = parts[i].split('=');
-                    if (part[0] === 'q' && !isNaN(part[1])) {
-                        qvalue = Number(part[1]);
+            if (!locale && (req.acceptedLanguages || req.headers)) {
+                var locales = req.acceptedLanguages ||
+                        _extractAcceptedLanguages(req.headers);
+                for (var i = 0, len = locales.length; i < len; i++) {
+                    _lng = locales[i];
+                    // get the first supported locale
+                    if (_isSupportedLocale(_lng)) {
+                        locale = _lng;
                         break;
+                    } else {
+                        var _lng2 = _stripRegion(_lng);           // locale without region code
+                        if (_lng !== _lng2 &&                     // prevents some useless function calls
+                                locales.indexOf(_lng2) === -1 &&  // ensures _lng2 is not listed later in accept-language
+                                _isSupportedLocale(_lng2)) {
+                            locale = _lng2;
+                            break;
+                        }
                     }
                 }
-
-                // add the tag and primary subtag to the qvalue associations
-                lngs.push({lng: parts[0], q: qvalue});
-            });
-
-            lngs.sort(function(a,b) {
-                return b.q - a.q;
-            });
-
-            for (i = 0; i < lngs.length; i++) {
-                locales.push(lngs[i].lng);
             }
-
-        } else {
-            locales.push(i18n.options.fallbackLng);
         }
 
-        return locales;
+        return locale || opts.fallbackLng;
     };
 
+
+    // 'en-GB' -> 'en'; 'zh-Hans-HK' -> 'zh-Hans';
+    function _stripRegion(locale) {
+        var _parts = locale.split(/[\-_]/)
+          , _end;
+        if (_parts.length > 1) {
+            _end = _parts[_parts.length - 1];
+            // ensures last part is a region code instead of a script
+            if (_end.length === 2) return locale.slice(0, -3);
+        }
+        return locale;
+    }
+
+
+    // 'en-GB;q=.8' -> ['en-GB', 0.8]
+    var _parseLocaleAndQuality = function(val) {
+        var _part = val.split(';'),
+          _lng = _part[0],
+          _q = _part[1] || 1;
+        if (isNaN(_q)) _q = parseFloat(_q.replace('q=', ''));
+        return [_lng, _q];
+    }
+
+    // return an array of user's accepted languages ordered by quality
+    var _extractAcceptedLanguages = function(headers) {
+        if (headers['accept-language']) {
+            var locales, _parts = headers['accept-language'].split(',');
+            // associate language tags by their 'q' value (between 1 and 0)
+            locales = _parts.map(_parseLocaleAndQuality);  // [['en-GB', 0.8], ['en', 0.6]]
+            locales.sort(function(a,b) { return b[1] - a[1]; }); // sorted by quality (DESC)
+            return locales.map(function(a) { return a[0]; }); // ['en-GB', 'en']
+        }
+        return [];
+    }
+    
 
     // overriding for the functions in i18next.js
     var f = {


### PR DESCRIPTION
Bug fixes and improvements for the `supportedLngs` option.

`supportedLngs` now may be:
- an array-like object of supported locales;
- a regexp or any object implementing a `.test(locale)` method;
- a string representing a single locale;
- false, disables locale format validation;

It now defaults to a simple regexp that validates common locale formats.

I've also extended the effect of `supportedLngs` to the querystring and accept-language methods for setting a locale.

More details may be found in the descriptions for the changesets.

I've tryed to run `make test` but the output wasn't very helpful. There's probably something missing in my environment (or skills) to run the tests properly since I've just started developing with node.js.

Anyway, thought to let you check it out as it is, just in case you could help with the tests... I'll try to see what's going on with the tests later today or maybe tomorrow.

Btw, thanks for sharing this code. : )
