### PR TITLE
Set default write concern for MongoDB

### DIFF
--- a/backends/mongoDb/sync.js
+++ b/backends/mongoDb/sync.js
@@ -35,7 +35,7 @@ module.exports = {
         var self = this;
 
         var server = new mongo.Server(options.host, options.port, options.options);
-        new mongo.Db(options.dbName , server, {}).open(function(err, client) {
+        new mongo.Db(options.dbName, server, {safe: true}).open(function(err, client) {
             if (err) {
                 if (callback) callback(err);
             } else {


### PR DESCRIPTION
Set default write concern for MongoDB to safe to assure things are synced properly and to remove ugly warning message for newer versions of MongoDB:

```
Please ensure that you set the default write concern for the database by setting
 one of the options

   w: (value of > -1 or the string 'majority'), where < 1 means
      no write acknowlegement
   journal: true/false, wait for flush to journal before acknowlegement
   fsync: true/false, wait for flush to file system before acknowlegement

For backward compatibility safe is still supported and
 allows values of [true | false | {j:true} | {w:n, wtimeout:n} | {fsync:true}]
 the default value is false which means the driver receives does not
 return the information of the success/error of the insert/update/remove

 ex: new Db(new Server('localhost', 27017), {safe:false})

 http://www.mongodb.org/display/DOCS/getLastError+Command

The default of no acknowlegement will change in the very near future

This message will disappear when the default safe is set on the driver Db
```
