### PR TITLE
Set default resGetPath values for webtranslate

### DIFF
--- a/lib/i18nextWTWrapper.js
+++ b/lib/i18nextWTWrapper.js
@@ -11,7 +11,7 @@ var defaults = {
     i18nextWTOptions: {
         languages: ['dev'],
         namespaces: ['translation'],
-        resGetPath: 'locales/__lng__/__ns__.json',
+        resGetPath: 'locales/resources.json?lng=__lng__&ns=__ns__',
         resChangePath: 'locales/change/__lng__/__ns__',
         resRemovePath: 'locales/remove/__lng__/__ns__',
         fallbackLng: 'dev',


### PR DESCRIPTION
Set default resGetPath values for webtranslate to match the one used by i18next.
