### PR TITLE
Properly support supportedLngs.

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -26,7 +26,7 @@
         options.sendMissing = options.saveMissing || false;
         options.detectLngFromPath = options.detectLngFromPath === undefined ? false : options.detectLngFromPath;
         options.forceDetectLngFromPath = options.forceDetectLngFromPath !== true ? false : options.forceDetectLngFromPath;
-        options.supportedLngs = [];
+        options.supportedLngs = options.supportedLngs || [];
         options.ignoreRoutes = options.ignoreRoutes || [];
         options.cookieName = options.cookieName || 'i18next';  
         resStore = options.resStore ? options.resStore : {};

--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -54,7 +54,15 @@
 
         if (locales.length === 0) locales.push(opts.fallbackLng || 'en');
 
-        return locales[0];
+        if (opts.supportedLngs.length === 0) return locales[0];
+
+        for (locale in locales) {
+            if (opts.supportedLngs.indexOf(locale) > -1) {
+                return locale;
+            }
+        }
+
+        return opts.fallbackLng || 'en'
     };
 
     var _extractLocales = function(headers) {


### PR DESCRIPTION
supportedLngs was not really supported. Furthermore, detecting from the request returned locales which might not even exist locally. Which were crashing the whole application with `TypeError: Cannot read property 'translation' of undefined` at `i18next/lib/filesync.js:30`.
