### PR TITLE
[WebTranslate] options.index can now accept a function

### DIFF
--- a/lib/i18nextWTWrapper.js
+++ b/lib/i18nextWTWrapper.js
@@ -140,11 +140,12 @@ module.exports = {
                 res.end();
                 return;
             }
-            if(typeof options.index === 'function') { 
-                req.locals.i18nextWTPath = options.path;
-                req.locals.i18nextWTResources = parseResources(options.resourceSets);
-                req.locals.i18nextWTOptions = JSON.stringify(options.i18nextWTOptions);
-                options.index(req, res);
+            if(typeof options.index === 'function') {
+                options.index(req, res, {
+                    i18nextWTPath: options.path
+                    , i18nextWTResources: parseResources(options.resourceSets)
+                    , i18nextWTOptions: JSON.stringify(options.i18nextWTOptions)
+                });
             } else {
                 var html = options.index;
                 html = html.replace('__i18nextWTOptions__', JSON.stringify(options.i18nextWTOptions));


### PR DESCRIPTION
There are use cases where users would like to have control over the rendering process of the web translator interface template. For those use cases we can allow options.index to accept a function:

index: function(req, res, options) {
   req.render('path/to/template', options);
};

options object contains the configuration variables which can be accessed from within a template: i18nextWTPath, i18nextWTResources, i18nextWTOptions
