### PR TITLE
add settings for cookie domain.

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -256,7 +256,7 @@
         var expirationDate = new Date();
         expirationDate.setFullYear(expirationDate.getFullYear() + 1);
 
-        cookies.set(i18n.options.cookieName, locale, { expires: expirationDate, httpOnly : false });
+        cookies.set(i18n.options.cookieName, locale, { expires: expirationDate, domain: i18n.options.cookieDomain, httpOnly : false });
     };
 
     i18n.addRoute = function(route, lngs, app, verb, fc) {


### PR DESCRIPTION
In some use cases there is a need to set the domain of the cookie to ".yourdomain.com". (to support all subdomains)
Only a small change is needed to support the **cookieDomain** option.

You can use that config like other options in the i18next.init function.

```
i18n.init({
    cookieName: "lang", 
    cookieDomain: ".yourdomain.com",
    ns: { namespaces: ['ns.common', 'ns.special'], defaultNs: 'ns.special'},
    resSetPath: 'locales/__lng__/new.__ns__.json',
    saveMissing: true,
    debug: true,
    sendMissingTo: 'fallback'
});
```

There is no need of a value fallback in the code because the domain option is ignored when it's null or undefined.
