### PR TITLE
Fixed a plus one error with options.detectLngFromPath

### DIFF
--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -19,7 +19,7 @@
     function detectLanguageFromPath(req, res, options) {
         var locale, locales = [];
         var parts = req.originalUrl.split('/');
-        if (parts.length > options.detectLngFromPath) {
+        if (parts.length > options.detectLngFromPath + 1) {
             var part = parts[options.detectLngFromPath + 1];
             var lookUp = wrapper.pluralExtensions.rules[part.split('-')[0]];
             if (lookUp) locale = part;
@@ -71,7 +71,7 @@
 
                 // get the language tag qvalue: 'q=0.8' -> 0.8
                 var qvalue = 1; // default qvalue
-                
+
                 for (i = 0; i < parts.length; i++) {
                     var part = parts[i].split('=');
                     if (part[0] === 'q' && !isNaN(part[1])) {
@@ -91,7 +91,7 @@
             for (i = 0; i < lngs.length; i++) {
                 locales.push(lngs[i]);
             }
-        } 
+        }
 
         return locales;
     };
@@ -120,8 +120,8 @@
     function cleanLngString(lng, options) {
         if (typeof lng === 'string' && lng.indexOf('-') > -1) {
             var parts = lng.split('-');
-    
-            lng = options.lowerCaseLng ? 
+
+            lng = options.lowerCaseLng ?
                 parts[0].toLowerCase() +  '-' + parts[1].toLowerCase() :
                 parts[0].toLowerCase() +  '-' + parts[1].toUpperCase();
         }
@@ -146,17 +146,17 @@
             }
 
             // from querystring
-            if (!locales.length) { 
+            if (!locales.length) {
                 locales = detectLanguageFromQuerystring(req, res, opts);
                 locales = checkAgainstSupportedLng(locales, opts.supportedLngs);
             }
-            
+
             // from cookie
             if (!locales.length && opts.useCookie) {
                 locales = detectLanguageFromCookie(req, res, opts);
                 locales = checkAgainstSupportedLng(locales, opts.supportedLngs);
             }
-            
+
             // from headers
             if (!locales.length && opts.detectLngFromHeaders) {
                 locales = detectLanguageFromHeader(req, res, opts);
@@ -176,7 +176,7 @@
             if (!source || typeof source === 'function') {
                 return target;
             }
-            
+
             for (var attr in source) { target[attr] = source[attr]; }
             return target;
         },
@@ -231,9 +231,9 @@
         checkAgainstSupportedLng: checkAgainstSupportedLng,
 
         cookie: {
-            create: function() {},           
-            read: function() {},           
-            remove: function() {} 
+            create: function() {},
+            read: function() {},
+            remove: function() {}
         }
     };
 
@@ -283,14 +283,14 @@
             // load each file individual
             f.each(ns.namespaces, function(nsIndex, nsValue) {
                 f.each(lngs, function(lngIndex, lngValue) {
-                    self.fetchOne(lngValue, nsValue, function(err, data) { 
+                    self.fetchOne(lngValue, nsValue, function(err, data) {
                         if (err) {
                             errors = errors || [];
                             errors.push(err);
                         }
 
                         store[lngValue] = store[lngValue] || {};
-                        
+
                         if (err) {
                             store[lngValue][nsValue] = {};
                         } else {


### PR DESCRIPTION
I'm having an issue with options.detectLngFromPath returning undefined if I specifc detectLngFromPath: 1 in the init options when trying to redirect. 

The use case is trying to redirect from / to /foo/:lng.

The issue is the options.deteLngFromPath + 1 isn't defined even though it is less than parts.length.
