### PR TITLE
Allow userland detectLanguage function and overriding other functions in init()

### DIFF
--- a/lib/dep/i18next.js
+++ b/lib/dep/i18next.js
@@ -598,6 +598,12 @@
         f.extend(o, options);
         delete o.fixLng; /* passed in each time */
     
+        // override functions: .log(), .detectLanguage(), etc
+        if (o.functions) {
+            delete o.functions;
+            f.extend(f, options.functions);
+        }
+
         // create namespace object if namespace is passed in as string
         if (typeof o.ns == 'string') {
             o.ns = { namespaces: [o.ns], defaultNs: o.ns};

--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -46,6 +46,11 @@
         }
 
         orgInit(options, cb);
+
+        // override functions: .log(), .detectLanguage(), etc
+        if (options.functions) {
+            i18n.functions.extend(i18n.functions, options.functions);
+        }
     };
 
     i18n.backend = function(sync) {

--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -16,6 +16,13 @@
     }
 
     // detection subfunctions
+    function detectLanguageFromUserland(req, res, options) {
+        var locale, locales = [];
+        locale = options.detectLanguageFn(req, res);
+        if (locale) locales.push({lng: cleanLngString(locale, options), q: 1});
+        return locales;
+    }
+
     function detectLanguageFromPath(req, res, options) {
         var locale, locales = [];
         var parts = req.originalUrl.split('/');
@@ -135,8 +142,14 @@
 
         if (typeof req === 'object') {
 
+            // user-land fn
+            if (!locales.length && opts.detectLanguageFn) {
+                locales = detectLanguageFromUserland(req, res, opts);
+                locales = checkAgainstSupportedLng(locales, opts.supportedLngs);
+            }
+
             // from path
-            if (opts.detectLngFromPath !== false) {
+            if (!locales.length && opts.detectLngFromPath !== false) {
                 locales = detectLanguageFromPath(req, res, opts);
                 locales = checkAgainstSupportedLng(locales, opts.supportedLngs);
 
@@ -338,6 +351,9 @@
     });
 
     f.extend(wrapper, i18n);
-    wrapper.detectLanguage = f.detectLanguage;
+    wrapper.detectLanguage = function () {
+        // use the real f.detectLanguage() in case .init() overwrote it
+        return wrapper.functions.detectLanguage.apply(wrapper, arguments);
+    };
 
 })();

--- a/test/i18next.detectLanguage.spec.js
+++ b/test/i18next.detectLanguage.spec.js
@@ -6,7 +6,7 @@ var i18n = require('../index')
 
 describe('i18next.detectLanguage.spec', function() {
 
-  var opts, app;
+  var opts, app, userlandLanguage;
 
   before(function(done) {
     opts = {
@@ -20,7 +20,10 @@ describe('i18next.detectLanguage.spec', function() {
       saveMissing: false,
       resStore: false,
       detectLngFromPath: 0,
-      debug: false
+      debug: false,
+      detectLanguageFn: function (req, res) {
+        return userlandLanguage; // most tests leave this blank meaning this step is ignored
+      }
     };
 
     app = express();
@@ -53,9 +56,23 @@ describe('i18next.detectLanguage.spec', function() {
   
   });
 
+  afterEach(function () {
+    userlandLanguage = null;
+  });
+
   describe('detect language functionality', function() {
 
     describe('without supported languages set', function() {
+
+      describe('by userland fn', function() {
+        userlandLanguage = 'de-CH';
+        it('it should return userland language', function(done) {
+          request(app)
+            .get('/getLng')
+            .expect('de-CH')
+            .expect(200, done);
+        });
+      });
 
       describe('by route', function() {
         it('it should return set language', function(done) {

--- a/test/i18next.init.spec.js
+++ b/test/i18next.init.spec.js
@@ -620,7 +620,79 @@ describe('i18next.init', function() {
         });
     
       });
+
+    });
+
+    // init/init.functions.spec.js
+
+    describe('with custom functions', function () {
+
+      var origDetectLanguage = i18n.functions.detectLanguage;
+      var origLog = i18n.functions.log;
+
+      afterEach(function() {
+        i18n.init(i18n.functions.extend(opts, {
+          functions: {
+            detectLanguage: origDetectLanguage,
+            log: origLog
+          }
+        }));
+      });
     
+      describe('to override detectLanguage.', function () {
+
+        var resStore = {
+          dev: { translation: { 'simple': 'ok_from_dev' } },
+          en: { translation: { 'simple': 'ok_from_en' } },
+          'en-us': { translation: { 'simple': 'ok_from_en-us' } }
+        };
+
+        beforeEach(function() {
+          i18n.init(i18n.functions.extend(opts, {
+            functions: {
+              detectLanguage: function(req, res, options) {
+                return 'dev';
+              }
+            },
+            resStore: resStore
+          }, function(t) { done(); }) );
+        });
+
+        it('it should override detectLanguage', function () {
+          expect(i18n.detectLanguage()).to.be('dev');
+        });
+
+      });
+
+      describe('to override log', function () {
+
+        var resStore = {
+          dev: { translation: { 'simple': 'ok_from_dev' } },
+          en: { translation: { 'simple': 'ok_from_en' } },
+          'en-us': { translation: { 'simple': 'ok_from_en-us' } }
+        };
+
+        var logData = [];
+
+        beforeEach(function() {
+          i18n.init(i18n.functions.extend(opts, {
+            lng: 'en-us',
+            functions: {
+              debug: true,
+              log: function(message) {
+                logData.push(message);
+              }
+            },
+            resStore: resStore
+          }, function(t) { done(); }) );
+        });
+
+        it('it should override log', function () {
+          expect(logData[0]).to.be('currentLng set to: en-US');
+        });
+
+      });
+
     });
 
   });


### PR DESCRIPTION
If I have a locale store that isn't the i18next cookie, it isn't the query string, and it isn't in the url, I have to clone the entire handle function and patch one line in https://github.com/jamuhl/i18next-node/blob/master/lib/i18next.js#L68 to get a request-specific locale.  With this patch, I can configure an override detectLanguage fn in #init, and if it isn't found, look in the normal places:

``` js
i18n.init({
  detectLanguageFn: function (req, res, options) {
    // return locale from session (if any), fall back to query, url, and cookie
    return req.session.locale;
  }
});
```

Or if I want to completely take over detecting the locale, I can also do so:
I can now also hook into logging to direct it elsewhere:

``` js
i18n.init({
  functions: {
    detectLanguage: function (req, res) {
      // return locale from session, don't use any other store
      return req.session.locale || 'en-US';
    }
  }
});
```

I can now also hook into logging to direct it elsewhere:

``` js
i18n.init({
  functions: {
    log: winston.info
  }
});
```

Tests that prove this behavior are also included.
