### PR TITLE
Allow multiple route callbacks

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -267,28 +267,6 @@
             verb = 'get';
         }
 
-        for (var i = 0, li = lngs.length; i < li; i++) {
-            var parts = route.split('/');
-            var locRoute = [];
-            for (var y = 0, ly = parts.length; y < ly; y++) {
-                var part = parts[y];
-                if (part.indexOf(':') === 0 || part === '') {
-                    locRoute.push(part);
-                } else {
-                    locRoute.push(i18n.t(part, { lng: lngs[i] }));
-                }
-            }
-
-            app[verb || 'get'](locRoute.join('/'), fc);
-        }
-    };
-
-    i18n.addRoute = function(route, lngs, app, verb, fc) {
-        if (typeof verb === 'function') {
-            fc = verb;
-            verb = 'get';
-        }
-
         // Combine `fc` and possible more callbacks to one array
         var callbacks = [fc].concat(Array.prototype.slice.call(arguments, 5));
 


### PR DESCRIPTION
The expressjs methods `app.get`, `app.post` etc. support multiple callbacks.

I use this feature to ensure the user is authenticated on specific routes:

```
app.get('/secure-page', ensureAuthenticated, securePageCallback);
```

The `i18n.addRoute` method only accepted only **one** callback, so I improved its functionality to work with my setup. I think this could be useful to everyone.
