### PR TITLE
Stop matching wrong languages

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -285,7 +285,7 @@
             // Apply the route and its callbacks
             // with a prepended middleware to ensure
             // :lng contains a supported language
-            app[verb || 'get'].apply(app, [locRoute.join('/'), ensureIsSupportedLanguage].concat(callbacks));
+            app[verb || 'get'].apply(app, [locRoute.join('/'), ensureIsSupportedLanguage(lngs)].concat(callbacks));
         }
     };
 
@@ -293,12 +293,14 @@
     // the parameter :lng to contain
     // a supported language.
     // If not, it skips the route.
-    function ensureIsSupportedLanguage(req, res, next) {
-        if (req.params.lng && i18n.options.supportedLngs.indexOf(req.params.lng) >= 0) {
-            return next();
-        }
+    function ensureIsSupportedLanguage(languages) {
+        return function (req, res, next) {
+            if (req.params.lng && languages.indexOf(req.params.lng) >= 0) {
+                return next();
+            }
 
-        next('route');
+            next('route');
+        };
     }
 
 })();


### PR DESCRIPTION
eac5923: An additional middleware (`ensureIsSupportedLanguage`) gets added to localized routes, that skips a matching route, if the language in the `:lng` parameter is not available in `i18n.options.supportedLngs`.

This is fixes #140 

It also contains my earlier pull-request #139 that allows multiple middlewares in the `addRoute` method.
