### PR TITLE
Static middleware has to stay after the index one

### DIFF
--- a/lib/i18nextWTWrapper.js
+++ b/lib/i18nextWTWrapper.js
@@ -132,9 +132,6 @@ module.exports = {
         options.i18nextWTOptions = extend(defaults.i18nextWTOptions, options.i18nextWTOptions || {}); // extend inner opts
         options = extend(defaults, options);
 
-        var path = require('path').resolve(__dirname + '/dep/i18nextWT');
-        app.use(options.path, express.static(path));
-
         app.get(options.path, function(req, res) {
             if (!options.authenticated(req, res)) {
                 res.end();
@@ -154,6 +151,9 @@ module.exports = {
                 res.send(html);
             }
         });
+        
+        var path = require('path').resolve(__dirname + '/dep/i18nextWT');
+        app.use(options.path, express.static(path));
     }
 
 };


### PR DESCRIPTION
If the static middleware is added before the index delivery middleware (app.get(path)) than the static index.html file gets delivered and the app doesn't work.
