### PR TITLE
Fix for error thrown by JSON.parse(body) in sync.js

### DIFF
--- a/backends/remoteSync/sync.js
+++ b/backends/remoteSync/sync.js
@@ -14,7 +14,11 @@ module.exports = {
             if (err) {
                 cb(err);
             } else {
-                cb(null, JSON.parse(body));
+                try {
+                    cb(null, JSON.parse(body));
+                } catch(err) {
+                    cb(new Error('error parsing' + url + ': ' + err.message));
+                }
             }
         });
     },


### PR DESCRIPTION
Fixed an fatal error thrown by "JSON.parse(body)" if "body" is no valid json object.