### PR TITLE
Default setJqueryExt to false in node environment

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -30,6 +30,7 @@
         options.supportedLngs = options.supportedLngs || [];
         options.ignoreRoutes = options.ignoreRoutes || [];
         options.cookieName = options.cookieName || 'i18next';
+        options.setJqueryExt = options.setJqueryExt || false;
         resStore = options.resStore ? options.resStore : {};
         
         // obsolete

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     , "jade": ">=0.0.1"
     , "benchmark": ">=0.0.1"
     , "microtime": ">=0.0.1"
+    , "jquery": ">=2.1.3"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Having this option defaulted to true causes an error on init if the jquery npm module is installed since jQuery exports a function that throws in a pure node environment - attempting to set $.fn.i18n fails since $.fn is undefined.

