### PR TITLE
Prevent tests from leaking state

### DIFF
--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -259,7 +259,7 @@
 
         reload: function (cb) {
             this.resStore = {};
-            i18n.setLng(i18n.lng, cb);
+            i18n.setLng(i18n.lng(), cb);
         },
 
         configure: function(rstore, options, functions) {

--- a/test/i18next.translate.spec.js
+++ b/test/i18next.translate.spec.js
@@ -37,6 +37,9 @@ describe('i18next.translate', function() {
       lngWhitelist: null
     };
   });
+  afterEach(function (done) {
+    i18n.sync.reload(function () { done(); });
+  });
 
   describe('keys with non supported values', function() {
   


### PR DESCRIPTION
The tests in "context usage" leave their modified resources in the internal store in i18n.sync.resStore - this means that subsequent tests load the state from the "context usage" tests rather than loading the files as one might expect.

This means that adding a simple test to the end of the suite will fail, but with the "context usage" tests commented out then they will pass.

Calling `i18n.sync.reload` after each test causes this state to be reset so that tests can be run independently without state leaking.