### PR TITLE
Fix lookup with `fallbackToDefaultNS` option

### DIFF
--- a/test/i18next.translate.spec.js
+++ b/test/i18next.translate.spec.js
@@ -1050,7 +1050,22 @@ describe('i18next.translate', function() {
       });
   
     });
-  
+
+  });
+
+  describe('falling back to default namespaces', function () {
+
+    it('falls back to default namespace if key cannot be found', function (done) {
+      i18n.init(i18n.functions.extend(opts, {
+            fallbackToDefaultNS: true,
+            fallbackOnEmpty: true,
+            fallbackOnNull: true }),
+          function(t) {
+            expect(t('simple_en-US', { ns: 'test-bom' })).to.equal('ok_from_en-US');
+            done();
+          });
+    });
+
   });
 
 });


### PR DESCRIPTION
Running a lookup with fallbackToDefaultNS flag was not actually doing the fallback, it was simply running the same lookup again with all of the same options - in particular the same namespace option - so it never found the fallback value.

When running the fallback lookup set the ns option to be the default namespace and re-run the lookup.

*Note: the test added will always fail unless #182 is merged*