### PR TITLE
Removed pluralExtensions lookup from detectLanguageFromPath

### DIFF
--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -27,9 +27,7 @@
         var locale, locales = [];
         var parts = req.originalUrl.split('/');
         if (parts.length > options.detectLngFromPath + 1) {
-            var part = parts[options.detectLngFromPath + 1];
-            var lookUp = wrapper.pluralExtensions.rules[part.split('-')[0]];
-            if (lookUp) locale = part;
+            locale = parts[options.detectLngFromPath + 1];
         }
         if (locale) locales.push({lng: cleanLngString(locale, options), q: 1});
         return locales;


### PR DESCRIPTION
As discussed at https://github.com/i18next/i18next-node/issues/175, I removed lines that forced pluralExtensions lookup when detectLanguageFromPath was called (since none of the others "detectLanguage" methods have this check in them). This allows use of custom language shortcodes, not just predefined ones).