### PR TITLE
Add support for authenticated redis databases

### DIFF
--- a/backends/redis/sync.js
+++ b/backends/redis/sync.js
@@ -26,7 +26,13 @@ module.exports = {
 
         var self = this;
 
-        this.client = redis.createClient(options.port, options.host);
+        // optional support for authentication by passing password or auth_pass in the options
+        var redisOpts = {};
+        if (options.auth_pass || options.password) {
+            redisOpts.auth_pass = options.auth_pass || options.password;
+        }
+
+        this.client = redis.createClient(options.port, options.host, redisOpts);
 
         this.client.on('ready', function () {
             if (options.database !== 0) {


### PR DESCRIPTION
Setting `auth_pass` or `password` in the connect options of the redis backend will use that password to authenticate to that redis database