### PR TITLE
Stop unnecessary reloading all namespaces

### DIFF
--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -279,7 +279,7 @@
                 toLoad[lng] = [];
 
                 for (var x = 0, len2 = namespaces.length; x < len2; x++) {
-                    if (!this.resStore[lng] || !this.resStore[lng][namespaces]) toLoad[lng].push(namespaces[x]);
+                    if (!this.resStore[lng] || !this.resStore[lng][namespaces[x]]) toLoad[lng].push(namespaces[x]);
                 }
             }
 


### PR DESCRIPTION
Fix bug in sync.load which causes all files to reload.