### PR TITLE
Fix ensureIsSupportedLanguage middleware injection.

### DIFF
--- a/lib/i18next.js
+++ b/lib/i18next.js
@@ -312,7 +312,7 @@
             // if ensureLngSupport is set to true (default)
             var routes = [locRoute.join('/')];
             if (i18n.options.ensureLngSupport) {
-              routes.concat(ensureIsSupportedLanguage(lngs));
+                routes.push(ensureIsSupportedLanguage(lngs));
             }
             app[verb || 'get'].apply(app, routes.concat(callbacks));
         }


### PR DESCRIPTION
addRoute() does not inject the ensureIsSupportedLangue middleware when ensureLngSupport is set.

Array.concat() return a new array, but at line 315 the result is ignored.
Changed .concat() to .push() to achieve the desired result.